### PR TITLE
Msft/ydave/arista eos dir flash

### DIFF
--- a/templates/arista_eos_dir_flash.template
+++ b/templates/arista_eos_dir_flash.template
@@ -1,3 +1,4 @@
+Value Filldown FILE_SYSTEM (\S+)
 Value PERMISSIONS (\S+)
 Value SIZE (\d+)
 Value DATE_TIME (\S+\s+\d+\s+((\d+)|(\d+:\d+)))
@@ -9,7 +10,10 @@ Start
   ^Directory of\s+${FILE_SYSTEM} -> DIR
 
 DIR
-  ^{PERMISSIONS}\s+{SIZE}\s+{DATE_TIME}\s{NAME} -> Record
-  ^${TOTAL_SIZE}\s+\S+\s+\S+\s+\({TOTAL_FREE}\s+\S+\s+\S+\)
+  ^\s+${PERMISSIONS}\s+${SIZE}\s+${DATE_TIME}\s+${NAME} -> Record
+  ^${TOTAL_SIZE}\s+\S+\s+\S+\s+\(${TOTAL_FREE}\s+\S+\s+\S+\)
+  ^\s+$$
+  ^$$
+  ^.* -> Error "LINE NOT FOUND"
 
 EOF

--- a/templates/arista_eos_dir_flash.template
+++ b/templates/arista_eos_dir_flash.template
@@ -1,0 +1,15 @@
+Value PERMISSIONS (\S+)
+Value SIZE (\d+)
+Value DATE_TIME (\S+\s+\d+\s+((\d+)|(\d+:\d+)))
+Value NAME (\S+)
+Value Fillup TOTAL_SIZE (\d+)
+Value Fillup TOTAL_FREE (\d+)
+
+Start
+  ^Directory of\s+${FILE_SYSTEM} -> DIR
+
+DIR
+  ^{PERMISSIONS}\s+{SIZE}\s+{DATE_TIME}\s{NAME} -> Record
+  ^${TOTAL_SIZE}\s+\S+\s+\S+\s+\({TOTAL_FREE}\s+\S+\s+\S+\)
+
+EOF

--- a/templates/index
+++ b/templates/index
@@ -44,6 +44,7 @@ arista_eos_bash_df_-h.template, .*, arista_eos, bas[[h]] d[[f]] [[-h]]
 arista_eos_show_clock.template, .*, arista_eos, sh[[ow]] clo[[ck]]
 arista_eos_show_mlag.template, .*, arista_eos, sh[[ow]] ml[[ag]]
 arista_eos_show_vlan.template, .*, arista_eos, sh[[ow]] vl[[an]]
+arista_eos_dir_flash.template, .*, arista_eos, dir fl[[ash:]]
 
 aruba_os_show_ipv6_interface_brief.template, .*, aruba_os, sh[[ow]] ipv6 in[[terface]] b[[rief]]
 aruba_os_show_ip_interface_brief.template, .*, aruba_os, sh[[ow]] ip in[[terface]] b[[rief]]

--- a/tests/arista_eos/dir_flash/arista_eos_dir_flash.parsed
+++ b/tests/arista_eos/dir_flash/arista_eos_dir_flash.parsed
@@ -1,0 +1,101 @@
+---
+parsed_sample:
+
+
+  file_system : 'flash:/'
+  permissions : '-rwx'
+  size : '591941836'
+  date_time : 'Aug 2  2017'
+  name : 'EOS-4.18.3.1F.swi'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : '-rwx'
+  size : '609823300'
+  date_time : 'Feb 14 02:03'
+  name : 'EOS-4.19.5M.swi'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : '-rwx'
+  size : '29'
+  date_time : 'Aug 23  2017'
+  name : 'boot-config'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : 'drwx'
+  size : '4096'
+  date_time : 'Aug 23  2017'
+  name : 'debug'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : '-rwx'
+  size : '0'
+  date_time : 'Apr 15  2017'
+  name : 'enable3px'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : '-rwx'
+  size : '19'
+  date_time : 'Apr 15  2017'
+  name : 'enable3px.key'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : '-rwx'
+  size : '31'
+  date_time : 'Apr 15  2017'
+  name : 'kickstart-config'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : 'drwx'
+  size : '4096'
+  date_time : 'Apr 3 10:29'
+  name : 'persist'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : 'drwx'
+  size : '4096'
+  date_time : 'Apr 15  2017'
+  name : 'schedule'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : '-rwx'
+  size : '20530'
+  date_time : 'Jan 18 22:46'
+  name : 'startup-config'
+  total_size : '3519041536'
+  total_free : '1725112320'
+
+
+  file_system : 'flash:/'
+  permissions : '-rwx'
+  size : '13'
+  date_time : 'Aug 23  2017'
+  name : 'zerotouch-config'
+  total_size : '3519041536'
+  total_free : '1725112320'

--- a/tests/arista_eos/dir_flash/arista_eos_dir_flash.raw
+++ b/tests/arista_eos/dir_flash/arista_eos_dir_flash.raw
@@ -1,0 +1,15 @@
+Directory of flash:/
+
+       -rwx   591941836            Aug 2  2017  EOS-4.18.3.1F.swi
+       -rwx   609823300           Feb 14 02:03  EOS-4.19.5M.swi
+       -rwx          29           Aug 23  2017  boot-config
+       drwx        4096           Aug 23  2017  debug
+       -rwx           0           Apr 15  2017  enable3px
+       -rwx          19           Apr 15  2017  enable3px.key
+       -rwx          31           Apr 15  2017  kickstart-config
+       drwx        4096            Apr 3 10:29  persist
+       drwx        4096           Apr 15  2017  schedule
+       -rwx       20530           Jan 18 22:46  startup-config
+       -rwx          13           Aug 23  2017  zerotouch-config
+
+3519041536 bytes total (1725112320 bytes free)


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
arista_eos_dir_flash.template, Arista 7050, dir flash:

##### SUMMARY
The command is useful to get the details of the files loaded in the flash drive. This information helps determine the disk space before loading a new OS image for upgrades

```
Directory of flash:/

       -rwx   591941836            Aug 2  2017  EOS-4.18.3.1F.swi
       -rwx   609823300           Feb 14 02:03  EOS-4.19.5M.swi
       -rwx          29           Aug 23  2017  boot-config
       drwx        4096           Aug 23  2017  debug
       -rwx           0           Apr 15  2017  enable3px
       -rwx          19           Apr 15  2017  enable3px.key
       -rwx          31           Apr 15  2017  kickstart-config
       drwx        4096            Apr 3 10:29  persist
       drwx        4096           Apr 15  2017  schedule
       -rwx       20530           Jan 18 22:46  startup-config
       -rwx          13           Aug 23  2017  zerotouch-config

3519041536 bytes total (1725112320 bytes free)
```
