### PR TITLE
fix key name for dell to match cisco and arista

### DIFF
--- a/ntc_templates/__init__.py
+++ b/ntc_templates/__init__.py
@@ -1,3 +1,3 @@
 """ntc_templates - Parse raw output from network devices and return structured data."""
 
-__version__ = '1.0.33.dev1'
+__version__ = '1.0.34.dev1'

--- a/templates/dell_force10_show_ip_bgp_ipv6_unicast_summary.template
+++ b/templates/dell_force10_show_ip_bgp_ipv6_unicast_summary.template
@@ -7,10 +7,10 @@ Value MSG_SENT (\d+)
 Value IN_QUEUE (\d+)
 Value OUT_QUEUE (\d+)
 Value UP_DOWN (\S+)
-Value STATE_PFX (\S+)
+Value STATE_PFXRCD (\S+)
 
 Start
   ^BGP.+\s+${ROUTER_ID}.*\s+${LOCAL_AS} -> Continue
-  ^${BGP_NEIGH}\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+\d+\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE_PFX} -> Record
+  ^${BGP_NEIGH}\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+\d+\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE_PFXRCD} -> Record
 
 EOF

--- a/templates/dell_force10_show_ip_bgp_summary.template
+++ b/templates/dell_force10_show_ip_bgp_summary.template
@@ -7,10 +7,10 @@ Value MSG_SENT (\d+)
 Value IN_QUEUE (\d+)
 Value OUT_QUEUE (\d+)
 Value UP_DOWN (\S+)
-Value STATE_PFX (\S+)
+Value STATE_PFXRCD (\S+)
 
 Start
   ^BGP.+\s+${ROUTER_ID}.*\s+${LOCAL_AS} -> Continue
-  ^${BGP_NEIGH}\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+\d+\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE_PFX} -> Record
+  ^${BGP_NEIGH}\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+\d+\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE_PFXRCD} -> Record
 
 EOF

--- a/tests/dell_force10/show_ip_bgp_ipv6_unicast_summary/dell_force10_show_ip_bgp_ipv6_unicast_summary.parsed
+++ b/tests/dell_force10/show_ip_bgp_ipv6_unicast_summary/dell_force10_show_ip_bgp_ipv6_unicast_summary.parsed
@@ -11,7 +11,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:06:'
-  state_pfx : '121'
+  state_pfxrcd : '121'
 
 
 - router_id : '35.86.198.119'
@@ -23,7 +23,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:06:'
-  state_pfx : '121'
+  state_pfxrcd : '121'
 
 
 - router_id : '35.86.198.119'
@@ -35,7 +35,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:06:'
-  state_pfx : '121'
+  state_pfxrcd : '121'
 
 
 - router_id : '35.86.198.119'
@@ -47,7 +47,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:06:'
-  state_pfx : '121'
+  state_pfxrcd : '121'
 
 
 - router_id : '35.86.198.119'
@@ -59,7 +59,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:06:'
-  state_pfx : '121'
+  state_pfxrcd : '121'
 
 
 - router_id : '35.86.198.119'
@@ -71,7 +71,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:06:'
-  state_pfx : '121'
+  state_pfxrcd : '121'
 
 
 - router_id : '35.86.198.119'
@@ -83,7 +83,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:06:'
-  state_pfx : '121'
+  state_pfxrcd : '121'
 
 
 - router_id : '35.86.198.119'
@@ -95,4 +95,4 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:06:'
-  state_pfx : '121'
+  state_pfxrcd : '121'

--- a/tests/dell_force10/show_ip_bgp_summary/dell_force10_show_ip_bgp_summary.parsed
+++ b/tests/dell_force10/show_ip_bgp_summary/dell_force10_show_ip_bgp_summary.parsed
@@ -11,7 +11,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:23:'
-  state_pfx : '1324'
+  state_pfxrcd : '1324'
 
 
 - router_id : '35.86.198.119'
@@ -23,7 +23,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:23:'
-  state_pfx : '1320'
+  state_pfxrcd : '1320'
 
 
 - router_id : '35.86.198.119'
@@ -35,7 +35,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:23:'
-  state_pfx : '1324'
+  state_pfxrcd : '1324'
 
 
 - router_id : '35.86.198.119'
@@ -47,7 +47,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:23:'
-  state_pfx : '1324'
+  state_pfxrcd : '1324'
 
 
 - router_id : '35.86.198.119'
@@ -59,7 +59,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:23:'
-  state_pfx : '1324'
+  state_pfxrcd : '1324'
 
 
 - router_id : '35.86.198.119'
@@ -71,7 +71,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:23:'
-  state_pfx : '1320'
+  state_pfxrcd : '1320'
 
 
 - router_id : '35.86.198.119'
@@ -83,7 +83,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:23:'
-  state_pfx : '1314'
+  state_pfxrcd : '1314'
 
 
 - router_id : '35.86.198.119'
@@ -95,7 +95,7 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '1w4d:04:23:'
-  state_pfx : '1314'
+  state_pfxrcd : '1314'
 
 
 - router_id : '35.86.198.119'
@@ -107,4 +107,4 @@ parsed_sample:
   in_queue : '0'
   out_queue : '0'
   up_down : '00:00:00'
-  state_pfx : 'Connect'
+  state_pfxrcd : 'Connect'


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT
<!--- Name of the template, os and command  -->
      modified:   templates/dell_force10_show_ip_bgp_ipv6_unicast_summary.template
        modified:   templates/dell_force10_show_ip_bgp_summary.template
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
