### PR TITLE
bugfix imports : since clitable not importable as a module now

### DIFF
--- a/ntc_templates/__init__.py
+++ b/ntc_templates/__init__.py
@@ -1,5 +1,5 @@
 """ntc_templates - Parse raw output from network devices and return structured data."""
 
 
-__version__ = '1.0.48.dev1'
+__version__ = '1.0.49.dev1'
 

--- a/ntc_templates/parse.py
+++ b/ntc_templates/parse.py
@@ -1,8 +1,10 @@
 """ntc_templates.parse."""
 import os
 import sys
-from clitable import CliTableError
-import clitable as clitable
+try:
+    from textfsm import clitable
+except ImportError:
+    import clitable
 
 
 def _get_template_dir():
@@ -36,7 +38,7 @@ def parse_output(platform=None, command=None, data=None):
     try:
         cli_table.ParseCmd(data, attrs)
         structured_data = _clitable_to_dict(cli_table)
-    except CliTableError as e:
+    except clitable.CliTableError as e:
         raise Exception('Unable to parse command "%s" on platform %s - %s' % (command, platform, str(e)))
         # Invalid or Missing template
         # module.fail_json(msg='parsing error', error=str(e))


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT
parse.py

##### SUMMARY
Textfsm recently changed as a package rather than a group of modules. This is causing imports to fail. The bugfix here is already done in ntc/ntc-templates repo.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
