### PR TITLE
Fixing Ntc template "sonic_linux_free_dash_m.template"

### DIFF
--- a/ntc_templates/__init__.py
+++ b/ntc_templates/__init__.py
@@ -1,5 +1,5 @@
 """ntc_templates - Parse raw output from network devices and return structured data."""
 
 
-__version__ = '1.0.52.dev1'
+__version__ = '1.0.53.dev1'
 

--- a/templates/sonic_linux_free_dash_m.template
+++ b/templates/sonic_linux_free_dash_m.template
@@ -11,13 +11,13 @@ Value USED_SWAP (\S+)
 Value FREE_SWAP (\S+)
 
 Start
-  ^\s+total.*cache
+  ^\s+total.+
   ^Mem:\s+${TOTAL_MEMORY}\s+${USED_MEMORY}\s+${FREE_MEMORY}\s+${SHARED_MEMORY}\s+${BUFFERS}\s+${CACHED}
   ^-\/\+\sbuffers/cache:\s+${USED_RAM}\s+${FREE_RAM}
   ^Swap:\s+${TOTAL_SWAP}\s+${USED_SWAP}\s+${FREE_SWAP} -> Record
+  ^\s+$$
+  ^$$
   ^.* -> Error "LINE NOT FOUND"
  
 
 EOF
-
-

--- a/templates/sonic_linux_free_dash_m.template
+++ b/templates/sonic_linux_free_dash_m.template
@@ -11,11 +11,13 @@ Value USED_SWAP (\S+)
 Value FREE_SWAP (\S+)
 
 Start
-  ^\s+total.*cached
+  ^\s+total.*cache
   ^Mem:\s+${TOTAL_MEMORY}\s+${USED_MEMORY}\s+${FREE_MEMORY}\s+${SHARED_MEMORY}\s+${BUFFERS}\s+${CACHED}
   ^-\/\+\sbuffers/cache:\s+${USED_RAM}\s+${FREE_RAM}
   ^Swap:\s+${TOTAL_SWAP}\s+${USED_SWAP}\s+${FREE_SWAP} -> Record
   ^.* -> Error "LINE NOT FOUND"
-
+ 
 
 EOF
+
+

--- a/tests/sonic/sonic_linux_free_dash_m/sonic_linux_free_dash_m.parsed
+++ b/tests/sonic/sonic_linux_free_dash_m/sonic_linux_free_dash_m.parsed
@@ -1,14 +1,14 @@
 parsed_sample:
 
 
- - total_memory : '3881'
-   used_memory : '1625'
-   free_memory : '2255'
-   shared_memory : '164'
-   buffers : '177'
-   cached : '677'
-   used_ram : '770'
-   free_ram : '3110'
+ - total_memory : '7936'
+   used_memory : '1888'
+   free_memory : '4187'
+   shared_memory : '37'
+   buffers : '1860'
+   cached : '5740'
+   used_ram : ''
+   free_ram : ''
    total_swap : '0'
    used_swap : '0'
    free_swap : '0'

--- a/tests/sonic/sonic_linux_free_dash_m/sonic_linux_free_dash_m.raw
+++ b/tests/sonic/sonic_linux_free_dash_m/sonic_linux_free_dash_m.raw
@@ -1,6 +1,5 @@
 user@hostname:~$ free -m
-             total       used       free     shared    buffers     cached
-Mem:          3881       1625       2255        164        177        677
--/+ buffers/cache:        770       3110
-Swap:            0          0          0
+               total        used        free      shared  buff/cache   available
+Mem:           7936        1888        4187          37        1860        5740
+Swap:             0           0           0
 user@hostname:~$ 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
Change in Ntc template "sonic_linux_free_dash_m.template". 

##### SUMMARY
We were unable to collect show tech on sonic as before collecting show tech, it checks for memory & CPU utilization. There was issue with memory Ntc template. "Free -m" is command we run to check memory utilization. We were getting different CLI output for this command on different version of SONIC. 
Output 1: 
                   total       used       free     shared    buffers     cached
Mem:          3953       1398       2555         60        124        568
-/+ buffers/cache:        705       3248
Swap:            0          0          0

Output 2: 
                     total        used        free      shared  buff/cache   available
Mem:           7936        1883        4491          24        1561        5764
Swap:             0           0           0

Template which we had earlier was not working on Output 2. Changes in template to make sure it runs for both set of output. 
